### PR TITLE
Update config to use server instead of api_url

### DIFF
--- a/config/datadog.spc
+++ b/config/datadog.spc
@@ -13,8 +13,7 @@ connection "datadog" {
   #   2. The `DD_CLIENT_APP_KEY` environment variable
   # app_key = "b1cf234c0ed4c567890b524a3b42f1bd91c111a1"
 
-  # The API URL. By default it is pointed to "https://api.datadoghq.com/"
-  # If working with the EU version of Datadog, use "https://api.datadoghq.eu/"
-  # Please note that this URL must not end with the /api/ path.
-  # api_url = "https://api.datadoghq.com/"
+  # The server Host. By default it is pointed to "datadoghq.com"
+  # If working with the EU version of Datadog, use "datadoghq.eu"
+  # server = "datadoghq.com"
 }

--- a/datadog/connection_config.go
+++ b/datadog/connection_config.go
@@ -8,9 +8,9 @@ import (
 type datadogConfig struct {
 	APIKey *string `cty:"api_key"`
 	AppKey *string `cty:"app_key"`
-	// By default it is https://api.datadoghq.com/
-	// If working with "EU" version of Datadog, use https://api.datadoghq.eu/
-	ApiURL *string `cty:"api_url"`
+	// By default it is datadoghq.com
+	// If working with "EU" version of Datadog, use datadoghq.eu
+	Server *string `cty:"server"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
@@ -20,7 +20,7 @@ var ConfigSchema = map[string]*schema.Attribute{
 	"app_key": {
 		Type: schema.TypeString,
 	},
-	"api_url": {
+	"server": {
 		Type: schema.TypeString,
 	},
 }

--- a/datadog/utils.go
+++ b/datadog/utils.go
@@ -2,11 +2,8 @@ package datadog
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
@@ -29,7 +26,7 @@ func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 	// Default to the env var settings
 	apiKey := os.Getenv("DD_CLIENT_API_KEY")
 	appKey := os.Getenv("DD_CLIENT_APP_KEY")
-	apiURL := "https://api.datadoghq.com/"
+	server := "datadoghq.com"
 
 	// Prefer config settings
 	config := GetConfig(d.Connection)
@@ -40,8 +37,8 @@ func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 	if config.AppKey != nil {
 		appKey = *config.AppKey
 	}
-	if config.ApiURL != nil {
-		apiURL = *config.ApiURL
+	if config.Server != nil {
+		server = *config.Server
 	}
 
 	// Error if the minimum config is not set
@@ -60,21 +57,11 @@ func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 		},
 	)
 
-	if apiURL != "" {
-		parsedAPIURL, parseErr := url.Parse(apiURL)
-		if parseErr != nil {
-			return ctx, nil, fmt.Errorf(`invalid API URL : %v`, parseErr)
-		}
-		if parsedAPIURL.Host == "" || parsedAPIURL.Scheme == "" {
-			return ctx, nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
-		}
-
-		strings.Split(parsedAPIURL.Host, "/")
+	if server != "" {
 		ctx = context.WithValue(ctx,
 			datadogV1.ContextServerVariables,
 			map[string]string{
-				"name":     parsedAPIURL.Host,
-				"protocol": parsedAPIURL.Scheme,
+				"site": server,
 			})
 	}
 
@@ -111,7 +98,7 @@ func connectV2(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 	// Default to the env var settings
 	apiKey := os.Getenv("DD_CLIENT_API_KEY")
 	appKey := os.Getenv("DD_CLIENT_APP_KEY")
-	apiURL := "https://api.datadoghq.com/"
+	server := "datadoghq.com"
 
 	// Prefer config settings
 	config := GetConfig(d.Connection)
@@ -122,8 +109,8 @@ func connectV2(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 	if config.AppKey != nil {
 		appKey = *config.AppKey
 	}
-	if config.ApiURL != nil {
-		apiURL = *config.ApiURL
+	if config.Server != nil {
+		server = *config.Server
 	}
 
 	// Error if the minimum config is not set
@@ -148,21 +135,11 @@ func connectV2(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 		map[string]string{"basePath": "v2"},
 	)
 
-	if apiURL != "" {
-		parsedAPIURL, parseErr := url.Parse(apiURL)
-		if parseErr != nil {
-			return ctx, nil, nil, fmt.Errorf(`invalid API URL : %v`, parseErr)
-		}
-		if parsedAPIURL.Host == "" || parsedAPIURL.Scheme == "" {
-			return ctx, nil, nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
-		}
-
-		strings.Split(parsedAPIURL.Host, "/")
+	if server != "" {
 		ctx = context.WithValue(ctx,
 			datadogV2.ContextServerVariables,
 			map[string]string{
-				"name":     parsedAPIURL.Host,
-				"protocol": parsedAPIURL.Scheme,
+				"site": server,
 			})
 	}
 


### PR DESCRIPTION
The `api_url` of the configuration file has currently no effect. The way to change the server has documented on the  `datadog-api-client-go` is to set the `site` property, see https://github.com/DataDog/datadog-api-client-go#changing-server

I thought it would be easier to rename the current configuration property from `api_url` to `server` has multiple values are possible (datadoghq.com us3.datadoghq.com us5.datadoghq.com datadoghq.eu ddog-gov.com).