### PR TITLE
Fix : Plugin not working with `api_url = "https://api.datadoghq.eu/"`. Fixes #7

### DIFF
--- a/datadog/table_datadog_dashboard.go
+++ b/datadog/table_datadog_dashboard.go
@@ -56,6 +56,7 @@ func listDashboards(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	resp, _, err := apiClient.DashboardsApi.ListDashboards(ctx, datadog.ListDashboardsOptionalParameters{})
 	if err != nil {
 		plugin.Logger(ctx).Error("datadog_dashboard.listDashboards", "query_error", err)
+		return nil, err
 	}
 
 	for _, dashboard := range resp.GetDashboards() {

--- a/datadog/table_datadog_integration_aws.go
+++ b/datadog/table_datadog_integration_aws.go
@@ -64,6 +64,7 @@ func listAWSIntegrations(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	resp, _, err := apiClient.AWSIntegrationApi.ListAWSAccounts(ctx, opts)
 	if err != nil {
 		plugin.Logger(ctx).Error("datadog_integration_aws.listAWSIntegrations", "query_error", err)
+		return nil, err
 	}
 
 	for _, account := range resp.GetAccounts() {

--- a/datadog/table_datadog_log_event.go
+++ b/datadog/table_datadog_log_event.go
@@ -88,6 +88,7 @@ func listLogEvent(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		resp, _, err := apiClient.LogsApi.ListLogsGet(ctx, opts)
 		if err != nil {
 			plugin.Logger(ctx).Error("datadog_log_event.listLogEvents", "query_error", err)
+			return nil, err
 		}
 
 		for _, log := range resp.GetData() {

--- a/datadog/table_datadog_logs_metric.go
+++ b/datadog/table_datadog_logs_metric.go
@@ -43,6 +43,7 @@ func listLogsMetrics(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	resp, _, err := apiClient.LogsMetricsApi.ListLogsMetrics(ctx)
 	if err != nil {
 		plugin.Logger(ctx).Error("datadog_logs_metric.listLogsMetrics", "query_error", err)
+		return nil, err
 	}
 
 	for _, logMetric := range resp.GetData() {

--- a/datadog/table_datadog_monitor.go
+++ b/datadog/table_datadog_monitor.go
@@ -63,6 +63,7 @@ func listMonitors(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	resp, _, err := apiClient.MonitorsApi.ListMonitors(ctx, opts)
 	if err != nil {
 		plugin.Logger(ctx).Error("datadog_monitor.listMonitors", "query_error", err)
+		return nil, err
 	}
 
 	for _, monitor := range resp {

--- a/datadog/table_datadog_permission.go
+++ b/datadog/table_datadog_permission.go
@@ -42,6 +42,7 @@ func listPermissions(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	resp, _, err := apiClient.RolesApi.ListPermissions(ctx)
 	if err != nil {
 		plugin.Logger(ctx).Error("datadog_permission.listPermissions", "query_error", err)
+		return nil, err
 	}
 
 	for _, permission := range resp.GetData() {

--- a/datadog/table_datadog_role.go
+++ b/datadog/table_datadog_role.go
@@ -62,6 +62,7 @@ func listRoles(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 		resp, _, err := apiClient.RolesApi.ListRoles(ctx, opts)
 		if err != nil {
 			plugin.Logger(ctx).Error("datadog_role.listRoles", "query_error", err)
+			return nil, err
 		}
 
 		for _, role := range resp.GetData() {

--- a/datadog/table_datadog_security_monitoring_rule.go
+++ b/datadog/table_datadog_security_monitoring_rule.go
@@ -63,6 +63,7 @@ func listSecurityMonitoringRules(ctx context.Context, d *plugin.QueryData, _ *pl
 		resp, _, err := apiClient.SecurityMonitoringApi.ListSecurityMonitoringRules(ctx, opts)
 		if err != nil {
 			plugin.Logger(ctx).Error("datadog_security_monitoring_rule.listSecurityMonitoringRules", "query_error", err)
+			return nil, err
 		}
 
 		for _, securityMonitoringRule := range resp.GetData() {

--- a/datadog/table_datadog_security_monitoring_signal.go
+++ b/datadog/table_datadog_security_monitoring_signal.go
@@ -96,6 +96,7 @@ func listSecurityMonitoringSignals(ctx context.Context, d *plugin.QueryData, _ *
 		resp, _, err := apiClient.SecurityMonitoringApi.ListSecurityMonitoringSignals(ctx, opts)
 		if err != nil {
 			plugin.Logger(ctx).Error("datadog_security_monitoring_signal.listSecurityMonitoringSignals", "query_error", err)
+			return nil, err
 		}
 
 		for _, securityMonitoringSignal := range resp.GetData() {

--- a/datadog/table_datadog_user.go
+++ b/datadog/table_datadog_user.go
@@ -75,6 +75,7 @@ func listUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 		resp, _, err := apiClient.UsersApi.ListUsers(ctx, opts)
 		if err != nil {
 			plugin.Logger(ctx).Error("datadog_user.listUsers", "query_error", err)
+			return nil, err
 		}
 
 		for _, user := range resp.GetData() {

--- a/datadog/utils.go
+++ b/datadog/utils.go
@@ -64,7 +64,7 @@ func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 
 		strings.Split(parsedAPIURL.Host, "/")
 		// If api url is passed, set and use the api name and protocol on ServerIndex{1}
-		ctx = context.WithValue(ctx, datadogV2.ContextServerIndex, 1)
+		ctx = context.WithValue(ctx, datadogV1.ContextServerIndex, 1)
 		ctx = context.WithValue(ctx,
 			datadogV1.ContextServerVariables,
 			map[string]string{

--- a/datadog/utils.go
+++ b/datadog/utils.go
@@ -70,6 +70,8 @@ func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 		}
 
 		strings.Split(parsedAPIURL.Host, "/")
+		// If api url is passed, set and use the api name and protocol on ServerIndex{1}
+		ctx = context.WithValue(ctx, datadogV2.ContextServerIndex, 1)
 		ctx = context.WithValue(ctx,
 			datadogV1.ContextServerVariables,
 			map[string]string{
@@ -158,6 +160,8 @@ func connectV2(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 		}
 
 		strings.Split(parsedAPIURL.Host, "/")
+		// If api url is passed, set and use the api name and protocol on ServerIndex{1}
+		ctx = context.WithValue(ctx, datadogV2.ContextServerIndex, 1)
 		ctx = context.WithValue(ctx,
 			datadogV2.ContextServerVariables,
 			map[string]string{

--- a/datadog/utils.go
+++ b/datadog/utils.go
@@ -73,12 +73,6 @@ func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 			})
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		datadogV1.ContextServerVariables,
-		map[string]string{"basePath": "v2"},
-	)
-
 	// Modify default client for retry handling
 	httpClientV1 := http.DefaultClient
 	ctOptions := CustomTransportOptions{}

--- a/datadog/utils.go
+++ b/datadog/utils.go
@@ -19,13 +19,6 @@ import (
 
 func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *datadogV1.APIClient, error) {
 
-	// Load connection from cache, which preserves throttling protection etc
-	// Not sure if we should cache this --  as we are modifying the context in this function
-	// cacheKey := "datadog_connect"
-	// if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
-	// 	return cachedData.(context.Context), nil
-	// }
-
 	// Default to the env var settings
 	apiKey := os.Getenv("DD_CLIENT_API_KEY")
 	appKey := os.Getenv("DD_CLIENT_APP_KEY")
@@ -102,13 +95,6 @@ func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 }
 
 func connectV2(ctx context.Context, d *plugin.QueryData) (context.Context, *datadogV2.APIClient, *datadogV2.Configuration, error) {
-
-	// Load connection from cache, which preserves throttling protection etc
-	// Not sure if we should cache this --  as we are modifying the context in this function
-	// cacheKey := "datadog_connect"
-	// if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
-	// 	return cachedData.(context.Context), nil
-	// }
 
 	// Default to the env var settings
 	apiKey := os.Getenv("DD_CLIENT_API_KEY")


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Time: 8.975788ms
+-----------------------+--------------------------------------+
| name                  | id                                   |
+-----------------------+--------------------------------------+
| Subhajit Kumar Mondal | 0f550528-30e1-11ec-9255-da7ad0900002 |
| turbot-router-events  | f0717bea-30b4-405a-9c8f-34f0b3d28804 |
| <null>                | 252dcb01-30e1-11ec-9255-da7ad0900002 |
| <null>                | 130f3218-38b8-11ec-9b20-da7ad0900002 |
| Lalit Bhardwaj        | 45c9984e-30a0-11ec-9224-da7ad0900002 |
+-----------------------+--------------------------------------+
> select name, id from datadog_eu.datadog_user

Time: 1.031153257s
+----------------+--------------------------------------+
| name           | id                                   |
+----------------+--------------------------------------+
| Lalit Bhardwaj | 26506476-4765-11ec-9a52-da7ad0900005 |
+----------------+--------------------------------------+
```
</details>

# Connection config
```
connection "datadog" {
  plugin  = "datadog"
  api_key = "reacted"
  app_key = "reacted"
}

connection "datadog_eu" {
  plugin  = "datadog"
  api_key = "reacted"
  app_key = "reacted"
  api_url = "https://api.datadoghq.eu/"
}
```