### PR TITLE
Add table for `datadog_host`

### DIFF
--- a/datadog/plugin.go
+++ b/datadog/plugin.go
@@ -17,6 +17,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		DefaultTransform: transform.FromCamel(),
 		TableMap: map[string]*plugin.Table{
 			"datadog_dashboard":                  tableDatadogDashboard(ctx),
+			"datadog_host":                       tableDatadogHost(ctx),
 			"datadog_integration_aws":            tableDatadogIntegrationAws(ctx),
 			"datadog_log_event":                  tableDatadogLogEvent(ctx),
 			"datadog_logs_metric":                tableDatadogLogsMetric(ctx),

--- a/datadog/table_datadog_host.go
+++ b/datadog/table_datadog_host.go
@@ -23,7 +23,21 @@ func tableDatadogHost(ctx context.Context) *plugin.Table {
 			// Top columns
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the host."},
 			{Name: "id", Type: proto.ColumnType_STRING, Description: "ID of the host."},
+			{Name: "up", Type: proto.ColumnType_BOOL, Description: "Whether the expected metrics for the host have been received or not."},
+
+			// Other useful columns
 			{Name: "aws_name", Type: proto.ColumnType_STRING, Description: "AWS name of the host."},
+			{Name: "last_reported_time", Type: proto.ColumnType_INT, Description: "Last time the host reported a metric data point."},
+			{Name: "is_muted", Type: proto.ColumnType_BOOL, Description: "Whether or not the host is muted."},
+			{Name: "mute_timeout", Type: proto.ColumnType_BOOL, Description: "The timeout of the mute applied to the host."},
+
+			// JSON columns
+			{Name: "aliases", Type: proto.ColumnType_JSON, Description: "Aliases that the host goes by"},
+			{Name: "apps", Type: proto.ColumnType_JSON, Description: "Datadog integrations reporting metrics for the host"},
+			{Name: "meta", Type: proto.ColumnType_JSON, Description: "Host metadata."},
+			{Name: "metrics", Type: proto.ColumnType_JSON, Description: "Metics collected from the host"},
+			{Name: "sources", Type: proto.ColumnType_JSON, Description: "Source or cloud provider associated with the host."},
+			{Name: "tags_by_source", Type: proto.ColumnType_JSON, Description: "A list of tags for each data source (AWS, Datadog Agent etc)"},
 		},
 	}
 }

--- a/datadog/table_datadog_host.go
+++ b/datadog/table_datadog_host.go
@@ -1,0 +1,62 @@
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	datadog "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
+)
+
+func tableDatadogHost(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "datadog_host",
+		Description: "A host is any piece of infrastructure that runs an instance of the Datadog Agent such as a bare metal instance, a VM or a container.",
+		List: &plugin.ListConfig{
+			Hydrate: listHosts,
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "name", Require: plugin.Optional},
+			},
+		},
+		Columns: []*plugin.Column{
+			// Top columns
+			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the host."},
+			{Name: "id", Type: proto.ColumnType_STRING, Description: "ID of the host."},
+			{Name: "aws_name", Type: proto.ColumnType_STRING, Description: "AWS name of the host."},
+		},
+	}
+}
+
+func listHosts(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	ctx, apiClient, err := connectV1(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("datadog_host.listHosts", "connection_error", err)
+		return nil, err
+	}
+
+	// https://github.com/DataDog/datadog-api-client-go/blob/master/api/v1/datadog/docs/MonitorsApi.md#listmonitors
+	// page := int64(0) // int64 | The page to start paginating from. If this argument is not specified, the request returns all monitors without pagination.
+	opts := datadog.ListHostsOptionalParameters{}
+
+	name := d.KeyColumnQualString("name")
+	if name != "" {
+		opts.WithFilter(fmt.Sprintf("exact:host:%s", name))
+	}
+
+	resp, _, err := apiClient.HostsApi.ListHosts(ctx, opts)
+	if err != nil {
+		plugin.Logger(ctx).Error("datadog_monitor.listMonitors", "query_error", err)
+		return nil, err
+	}
+
+	for _, host := range *resp.HostList {
+		d.StreamListItem(ctx, host)
+		// Check if context has been cancelled or if the limit has been hit (if specified)
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/datadog/table_datadog_host.go
+++ b/datadog/table_datadog_host.go
@@ -7,12 +7,18 @@ import (
 	datadog "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v3/plugin/transform"
 )
 
 func tableDatadogHost(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
 		Name:        "datadog_host",
-		Description: "A host is any piece of infrastructure that runs an instance of the Datadog Agent such as a bare metal instance, a VM or a container.",
+		Description: "A host is any piece of infrastructure that runs an instance of the Datadog Agent such as a bare metal instance or a VM.",
+		// There is no Datadog hosts endpoint for getting a single host so instead we use a filter to perform an exact match
+		Get: &plugin.GetConfig{
+			Hydrate:    listHosts,
+			KeyColumns: plugin.SingleColumn("name"),
+		},
 		List: &plugin.ListConfig{
 			Hydrate: listHosts,
 			KeyColumns: plugin.KeyColumnSlice{
@@ -23,21 +29,21 @@ func tableDatadogHost(ctx context.Context) *plugin.Table {
 			// Top columns
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the host."},
 			{Name: "id", Type: proto.ColumnType_STRING, Description: "ID of the host."},
-			{Name: "up", Type: proto.ColumnType_BOOL, Description: "Whether the expected metrics for the host have been received or not."},
+			{Name: "up", Type: proto.ColumnType_BOOL, Description: "Whether the expected metrics for the host are being received or not."},
 
 			// Other useful columns
 			{Name: "aws_name", Type: proto.ColumnType_STRING, Description: "AWS name of the host."},
-			{Name: "last_reported_time", Type: proto.ColumnType_INT, Description: "Last time the host reported a metric data point."},
+			{Name: "last_reported_time", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromGo().Transform(transform.UnixToTimestamp), Description: "Last time the host reported a metric data point."},
 			{Name: "is_muted", Type: proto.ColumnType_BOOL, Description: "Whether or not the host is muted."},
 			{Name: "mute_timeout", Type: proto.ColumnType_BOOL, Description: "The timeout of the mute applied to the host."},
 
 			// JSON columns
-			{Name: "aliases", Type: proto.ColumnType_JSON, Description: "Aliases that the host goes by"},
-			{Name: "apps", Type: proto.ColumnType_JSON, Description: "Datadog integrations reporting metrics for the host"},
-			{Name: "meta", Type: proto.ColumnType_JSON, Description: "Host metadata."},
-			{Name: "metrics", Type: proto.ColumnType_JSON, Description: "Metics collected from the host"},
-			{Name: "sources", Type: proto.ColumnType_JSON, Description: "Source or cloud provider associated with the host."},
-			{Name: "tags_by_source", Type: proto.ColumnType_JSON, Description: "A list of tags for each data source (AWS, Datadog Agent etc)"},
+			{Name: "aliases", Type: proto.ColumnType_JSON, Description: "An array of aliases that the host is known by such as AWS EC2 instance name, AWS internal IP address etc."},
+			{Name: "apps", Type: proto.ColumnType_JSON, Description: "An array containing host apps such as system services, containers and more."},
+			{Name: "meta", Type: proto.ColumnType_JSON, Description: "An object containing host metadata such as operating system and version."},
+			{Name: "metrics", Type: proto.ColumnType_JSON, Description: "An object containing host metrics such as CPU, iowait and load."},
+			{Name: "sources", Type: proto.ColumnType_JSON, Description: "An array containing the sources of the host metrics."},
+			{Name: "tags_by_source", Type: proto.ColumnType_JSON, Description: "An object containing tags for each data source such as AWS, Datadog Agent etc."},
 		},
 	}
 }
@@ -49,27 +55,46 @@ func listHosts(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 		return nil, err
 	}
 
-	// https://github.com/DataDog/datadog-api-client-go/blob/master/api/v1/datadog/docs/MonitorsApi.md#listmonitors
-	// page := int64(0) // int64 | The page to start paginating from. If this argument is not specified, the request returns all monitors without pagination.
 	opts := datadog.ListHostsOptionalParameters{}
 
 	name := d.KeyColumnQualString("name")
+	hostNameFilter := fmt.Sprintf("exact:host:%s", name)
 	if name != "" {
-		opts.WithFilter(fmt.Sprintf("exact:host:%s", name))
+		opts.WithFilter(hostNameFilter)
 	}
 
-	resp, _, err := apiClient.HostsApi.ListHosts(ctx, opts)
-	if err != nil {
-		plugin.Logger(ctx).Error("datadog_monitor.listMonitors", "query_error", err)
-		return nil, err
-	}
+	opts.WithCount(1000)
+	opts.WithIncludeHostsMetadata(true)
+	opts.WithIncludeMutedHostsData(true)
 
-	for _, host := range *resp.HostList {
-		d.StreamListItem(ctx, host)
-		// Check if context has been cancelled or if the limit has been hit (if specified)
-		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+	paging := true
+	count := int64(0)
+
+	for paging {
+		resp, _, err := apiClient.HostsApi.ListHosts(ctx, opts)
+		if err != nil {
+			plugin.Logger(ctx).Error("datadog_monitor.listMonitors", "query_error", err)
+			return nil, err
+		}
+
+		for _, host := range *resp.HostList {
+			count += resp.GetTotalReturned()
+			d.StreamListItem(ctx, host)
+			// Check if context has been cancelled or if the limit has been hit (if specified)
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		// Break loop if using a filter, which is guaranteed to be an exact match
+		if name != "" {
 			return nil, nil
 		}
+		// Break loop if host list is less than the maximum page size of 1000 items
+		if count > 1000 {
+			return nil, nil
+		}
+		opts.WithFrom(count)
 	}
 
 	return nil, nil

--- a/docs/tables/datadog_host.md
+++ b/docs/tables/datadog_host.md
@@ -1,0 +1,64 @@
+# Table: datadog_dashboard
+
+A host is any piece of infrastructure that the Datadog Agent is installed on such as a bare-metal server or a cloud virtual machine, regardless of provider.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  up,
+  last_reported_time,
+  is_muted,
+  jsonb_pretty(aliases) as aliases
+from
+  datadog_host;
+```
+
+### Find hosts that don't use systemd and contain the AWS region `ap-southeast-2` in their DNS record
+
+```sql
+select
+  name,
+  jsonb_pretty(apps) as apps
+from
+  datadog_host
+where
+  not apps @> '["systemd"]'::jsonb
+  and name like '%ap-southeast-2%';
+```
+
+### Count instance sizes of each host by their attached AWS tags
+
+```sql
+select
+  tags,
+  count(tags)
+from
+  (select
+    jsonb_array_elements_text(tags_by_source->'Amazon Web Services') as tags
+    from
+      datadog_host
+  ) as foo
+where
+  tags like '%instance-type%'
+group by
+  tags;
+```
+
+
+### List hosts that have reported metrics within the last 10 minutes
+
+```sql
+select
+  name,
+  last_reported_time,
+  up
+from
+  datadog_host
+where
+  last_reported_time > current_timestamp - interval '10 minutes';
+```


### PR DESCRIPTION
# Tables added
```
+------------------------------------+-------------------------------------------------------------------------------------------------------------------------+
| table                              | description                                                                                                             |
+------------------------------------+-------------------------------------------------------------------------------------------------------------------------+
| datadog_host                       | A host is any piece of infrastructure that runs an instance of the Datadog Agent such as a bare metal instance or a VM. |
+------------------------------------+-------------------------------------------------------------------------------------------------------------------------+
```

Closes: #19

This is my first steampipe contribution so I expect I might have overlooked some things but I've tried to adhere to the style of the existing tables where possible.

There are a few things worth pointing out:

* While I've tried to wire up pagination properly, my workplace doesn't actually have enough hosts to properly test that it actually works (the page limit is 1000+)
* I don't really understand the specifics of hydration when it comes to the absence of something. The [Datadog hosts API](https://docs.datadoghq.com/api/latest/hosts/) will apparently serve results for any host that is live within the last 3 hours by default. Presumably if you were to open Steampipe, close it then open it again in a week, Steampipe would still retain older hosts rather than magically setting `up` to false. If Steampipe removes an entry from the table upon trying to rehydrate it and getting a 404, then this isn't such a big deal but either way, it kind of makes the `up` field redundant if it is always set to `true`
* While I tried to craft some more "Advanced" queries, I'm not that great with SQL so some queries can probably be rewritten to be less complex
* I haven't mapped `host_name`, which is available in the hosts API, as it appears to contain the exact same data as `name` based on the description.

Anyway, I didn't worry too much about the edge cases since they can be ironed out over time I'm sure.

You can do quite a lot of fun queries by making use of `jsonb` which I've heard about for a few years now but I've never actually seen it in action before now.

<img width="1291" alt="CleanShot 2022-07-23 at 17 49 34@2x" src="https://user-images.githubusercontent.com/14816406/180592462-3778a0d0-cbb5-4220-8062-02c0fa8e32c5.png">

