### PR TITLE
Use Search API in datadog_service_level_objective table to populate column values, closes #63

### DIFF
--- a/datadog/table_datadog_service_level_objective.go
+++ b/datadog/table_datadog_service_level_objective.go
@@ -2,6 +2,12 @@ package datadog
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
 
 	datadog "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -22,27 +28,31 @@ func tableDatadogServiceLevelObjective(ctx context.Context) *plugin.Table {
 		},
 		Columns: []*plugin.Column{
 			// Top columns
-			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the SLO."},
-			{Name: "id", Type: proto.ColumnType_STRING, Description: "ID of the SLO."},
-			{Name: "creator_email", Type: proto.ColumnType_STRING, Transform: transform.FromField("Creator.Email"), Description: "Email of the creator."},
-			{Name: "created_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("CreatedAt").Transform(convertDatetime), Description: "Timestamp of the SLO creation."},
+			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the SLO.", Transform: transform.FromField("Attributes.Name")},
+			{Name: "id", Type: proto.ColumnType_STRING, Transform: transform.FromGo(), Description: "ID of the SLO."},
+			{Name: "creator_email", Type: proto.ColumnType_STRING, Transform: transform.FromField("Attributes.Creator.Email"), Description: "Email of the creator."},
+			{Name: "created_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Attributes.CreatedAt").Transform(transform.NullIfZeroValue).Transform(convertDatetime), Description: "Timestamp of the SLO creation."},
 			{Name: "type", Type: proto.ColumnType_STRING, Description: "The type of the SLO. For more information about type, see https://docs.datadoghq.com/monitors/service_level_objectives/."},
 
 			// Other useful columns
-			{Name: "modified_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("ModifiedAt").Transform(convertDatetime), Description: "Last timestamp when the monitor was edited."},
+			{Name: "modified_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Attributes.ModifiedAt").Transform(transform.NullIfZeroValue).Transform(convertDatetime), Description: "Last timestamp when the monitor was edited."},
 
 			// JSON columns
 			{Name: "configured_alert_ids", Type: proto.ColumnType_JSON, Hydrate: getSLO, Description: "Get the IDs of SLO monitors that reference this SLO."},
-			{Name: "description", Type: proto.ColumnType_JSON, Description: "Description of the SLO."},
-			{Name: "groups", Type: proto.ColumnType_JSON, Hydrate: getSLO, Description: "A list of (up to 20) monitor groups that narrow the scope of a monitor service level objective."},
-			{Name: "monitor_ids", Type: proto.ColumnType_JSON, Description: "A list of monitor ids that defines the scope of a monitor service level objective."},
-			{Name: "query", Type: proto.ColumnType_JSON, Description: "The Metric based SLOs use queries to determine the state. Shows associated query."},
-			{Name: "monitor_tags", Type: proto.ColumnType_JSON, Description: "If monitors that are associated with SLO have tags they will show here."},
-			{Name: "tags", Type: proto.ColumnType_JSON, Description: "Tags associated with SLO."},
-			{Name: "thresholds", Type: proto.ColumnType_JSON, Description: "Thresholds that are set for the SLOs."},
+			{Name: "description", Type: proto.ColumnType_JSON, Description: "Description of the SLO.", Transform: transform.FromField("Attributes.Description")},
+			{Name: "groups", Type: proto.ColumnType_JSON, Description: "A list of (up to 20) monitor groups that narrow the scope of a monitor service level objective.", Transform: transform.FromField("Attributes.Groups")},
+			{Name: "monitor_ids", Type: proto.ColumnType_JSON, Description: "A list of monitor ids that defines the scope of a monitor service level objective.", Transform: transform.FromField("Attributes.MonitorIDs")},
+			{Name: "query", Type: proto.ColumnType_JSON, Description: "The Metric based SLOs use queries to determine the state. Shows associated query.", Transform: transform.FromField("Attributes.Query")},
+			{Name: "monitor_tags", Type: proto.ColumnType_JSON, Description: "If monitors that are associated with SLO have tags they will show here.", Transform: transform.FromField("Attributes.MonitorTags")},
+			{Name: "tags", Type: proto.ColumnType_JSON, Description: "Tags associated with SLO.", Transform: transform.FromField("Attributes.AllTags")},
+			{Name: "thresholds", Type: proto.ColumnType_JSON, Description: "Thresholds that are set for the SLOs.", Transform: transform.FromField("Attributes.Thresholds")},
 		},
 	}
 }
+
+// Using `apiClient.ServiceLevelObjectivesApi.SearchSLO` doesn't populate the response and returns empty rows.
+// Additionally, `apiClient.ServiceLevelObjectivesApi.ListSLOs(ctx, opts)` does not return SLOs of the "By Time Slice" type.
+// Therefore, we opted for a raw API call to list all the SLOs (as is done in the Datadog console). This approach also addresses the issue: https://github.com/turbot/steampipe-plugin-datadog/issues/63.
 
 func listSLOs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	ctx, apiClient, err := connectV1(ctx, d)
@@ -51,35 +61,90 @@ func listSLOs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 		return nil, err
 	}
 
-	opts := datadog.ListSLOsOptionalParameters{}
-
-	if d.QueryContext.Limit != nil {
-		opts.Limit = d.QueryContext.Limit
+	steampipeConfig := GetConfig(d.Connection)
+	apiKey := os.Getenv("DD_CLIENT_API_KEY")
+	appKey := os.Getenv("DD_CLIENT_APP_KEY")
+	if steampipeConfig.APIKey != nil {
+		apiKey = *steampipeConfig.APIKey
 	}
-
-	resp, _, err := apiClient.ServiceLevelObjectivesApi.ListSLOs(ctx, opts)
-
-	if err != nil {
-		plugin.Logger(ctx).Error("datadog_service_level_objective.listSLOs", "query_error", err)
-		return nil, err
+	if steampipeConfig.AppKey != nil {
+		appKey = *steampipeConfig.AppKey
 	}
+	// Prepare query parameters
 
-	for _, slo := range resp.GetData() {
-		d.StreamListItem(ctx, slo)
-		// Check if context has been cancelled or if the limit has been hit (if specified)
-		if d.RowsRemaining(ctx) == 0 {
-			return nil, nil
+	pageNumber := 0
+	for {
+
+		params := url.Values{}
+		params.Add("query", "")
+		params.Add("sort", "")
+		params.Add("include_facets", "false")
+		params.Add("include_permissions", "true")
+		params.Add("page[size]", "1")
+
+		params.Add("page[number]", fmt.Sprint(pageNumber))
+
+		fullUrl := fmt.Sprintf("%s?%s", *steampipeConfig.ApiURL+"api/v1/slo/search", params.Encode())
+
+		plugin.Logger(ctx).Error("Full URL : ", fullUrl)
+		buildReq, err := http.NewRequest("GET", fullUrl, nil)
+		if err != nil {
+			fmt.Println("Error creating the request:", err)
+			return nil, err
 		}
+
+		// Set headers
+		buildReq.Header.Set("Content-Type", "application/json")
+		buildReq.Header.Set("Accept", "*/*")
+		buildReq.Header.Set("DD-API-KEY", apiKey)
+		buildReq.Header.Set("DD-APPLICATION-KEY", appKey)
+
+		response, err := SearchSLO(apiClient, buildReq)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, slo := range response.Data.Attributes.SLOs {
+			d.StreamListItem(ctx, slo.Data)
+
+			// Check if context has been cancelled or if the limit has been hit (if specified)
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		if *response.Meta.Pagination.LastNumber == pageNumber {
+			break
+		}
+		pageNumber++
 	}
 
 	return nil, nil
+}
+
+func SearchSLO(client *datadog.APIClient, req *http.Request) (*ApiResponse, error) {
+	resp, err := client.CallAPI(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	response := &ApiResponse{}
+	err = json.Unmarshal(body, response)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
 }
 
 func getSLO(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
 	var sloID string
 	if h.Item != nil {
-		sloID = *h.Item.(datadog.ServiceLevelObjective).Id
+		sloID = h.Item.(*SLOData).ID
 	} else {
 		sloID = d.EqualsQuals["id"].GetStringValue()
 	}
@@ -110,4 +175,128 @@ func getSLO(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (in
 	}
 
 	return resp.GetData(), nil
+}
+
+// Root structure to represent the API response
+type ApiResponse struct {
+	Data  DataResponse  `json:"data"`
+	Meta  MetaResponse  `json:"meta"`
+	Links LinksResponse `json:"links"`
+}
+
+type DataResponse struct {
+	Type       string        `json:"type"`
+	Attributes SLOAttributes `json:"attributes"`
+}
+
+type SLOAttributes struct {
+	SLOs []SLOResponse `json:"slos"`
+}
+
+type SLOResponse struct {
+	Data *SLOData `json:"data"`
+}
+
+type SLOData struct {
+	Type       string                `json:"type"`
+	Attributes *SLOAttributesDetails `json:"attributes"`
+	ID         string                `json:"id"`
+}
+
+type SLOAttributesDetails struct {
+	Timeframe        *string         `json:"timeframe"`
+	WarningThreshold *float64        `json:"warning_threshold"`
+	Groups           interface{}     `json:"groups"`
+	Thresholds       []Threshold     `json:"thresholds"`
+	CreatedAt        *int64          `json:"created_at"`
+	Status           SLOStatus       `json:"status"`
+	TeamTags         []string        `json:"team_tags"`
+	ModifiedAt       *int64          `json:"modified_at"`
+	OverallStatus    []OverallStatus `json:"overall_status"`
+	AllTags          []string        `json:"all_tags"`
+	Query            *Query          `json:"query,omitempty"`
+	RequestContext   RequestContext  `json:"request_context"`
+	MonitorIDs       []int           `json:"monitor_ids,omitempty"`
+	MonitorTags      []int           `json:"monitor_tags,omitempty"`
+	ServiceTags      []string        `json:"service_tags"`
+	Name             *string         `json:"name"`
+	Description      interface{}     `json:"description"`
+	SLOType          *string         `json:"slo_type"`
+	TargetThreshold  *float64        `json:"target_threshold"`
+	Creator          Creator         `json:"creator"`
+	EnvTags          []string        `json:"env_tags"`
+}
+
+type Threshold struct {
+	TargetDisplay  *string     `json:"target_display"`
+	Timeframe      *string     `json:"timeframe"`
+	WarningDisplay interface{} `json:"warning_display"`
+	Warning        interface{} `json:"warning"`
+	Target         *float64    `json:"target"`
+}
+
+type SLOStatus struct {
+	CalculationError        interface{}     `json:"calculation_error"`
+	IndexedAt               *int64          `json:"indexed_at"`
+	SpanPrecision           *int            `json:"span_precision"`
+	RawErrorBudgetRemaining BudgetRemaining `json:"raw_error_budget_remaining"`
+	ErrorBudgetRemaining    *float64        `json:"error_budget_remaining"`
+	State                   *string         `json:"state"`
+	SLI                     *float64        `json:"sli"`
+}
+
+type BudgetRemaining struct {
+	Value float64 `json:"value"`
+	Unit  string  `json:"unit"`
+}
+
+type OverallStatus struct {
+	Status                  float64         `json:"status"`
+	Timeframe               string          `json:"timeframe"`
+	IndexedAt               int64           `json:"indexed_at"`
+	SpanPrecision           int             `json:"span_precision"`
+	RawErrorBudgetRemaining BudgetRemaining `json:"raw_error_budget_remaining"`
+	ErrorBudgetRemaining    float64         `json:"error_budget_remaining"`
+	Error                   interface{}     `json:"error"`
+	State                   string          `json:"state"`
+	Target                  float64         `json:"target"`
+}
+
+type Query struct {
+	Metrics     interface{} `json:"metrics"`
+	Denominator string      `json:"denominator"`
+	Numerator   string      `json:"numerator"`
+}
+
+type RequestContext struct {
+	UserHasWriteAccessForSLO bool `json:"user_has_write_access_for_slo"`
+}
+
+type Creator struct {
+	Name  string `json:"name"`
+	ID    int    `json:"id"`
+	Email string `json:"email"`
+}
+
+type MetaResponse struct {
+	Pagination *Pagination `json:"pagination"`
+}
+
+type Pagination struct {
+	Number      *int    `json:"number"`
+	FirstNumber *int    `json:"first_number"`
+	PrevNumber  *int    `json:"prev_number"`
+	NextNumber  *int    `json:"next_number"`
+	LastNumber  *int    `json:"last_number"`
+	Size        *int    `json:"size"`
+	Type        *string `json:"type"`
+	Total       *int    `json:"total"`
+}
+
+type LinksResponse struct {
+	Self  string `json:"self"`
+	Last  string `json:"last"`
+	Next  string `json:"next"`
+	Prev  string `json:"prev"`
+	First string `json:"first"`
 }


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from datadog_service_level_objective
+------------+----------------------------------+----------------------------------+---------------------------+------+---------------------------+----------------------+-------------+--------+-------------+----------------------------------------------------------------------------------------------------------->
| name       | id                               | creator_email                    | created_at                | type | modified_at               | configured_alert_ids | description | groups | monitor_ids | query                                                                                                     >
+------------+----------------------------------+----------------------------------+---------------------------+------+---------------------------+----------------------+-------------+--------+-------------+----------------------------------------------------------------------------------------------------------->
| time-slice | 914a0ed151605a88a9520964f5bd009c | xxxxxxxxxxxxxxxxxxxxxx@gmail.com | 2024-09-26T12:58:07+05:30 | slo  | 2024-09-26T12:58:07+05:30 | <null>               | <null>      | <null> | <null>      | <null>                                                                                                    >
| testalert  | 656b743ae253584899c02064ac7ad4cd | xxxxxxxxxxxxxxxxxxxxxx@gmail.com | 2024-09-26T12:56:57+05:30 | slo  | 2024-09-26T12:56:57+05:30 | []                   | <null>      | <null> | <null>      | {"denominator":"count:datadog.event.tracking.intake.monresult.bytes{*}.as_count()","metrics":null,"numerat>
| tes43      | b18382d82b9f5a2ea46849a984e948a5 | xxxxxxxxxxxxxxxxxxxxxx@gmail.com | 2024-09-26T11:08:50+05:30 | slo  | 2024-09-26T11:08:50+05:30 | []                   | <null>      | <null> | [1118060]   | <null>                                                                                                    >
| test53     | 5ec04d26847356268838092d0b8506cc | xxxxxxxxxxxxxxxxxxxxxx@gmail.com | 2024-09-26T10:54:20+05:30 | slo  | 2024-09-26T10:54:20+05:30 | []                   | <null>      | <null> | <null>      | {"denominator":"count:datadog.event.tracking.indexation.audit.events{*}.as_count()","metrics":null,"numera>
| test53     | ddfe3bd205b953ebbd44334bce972cf1 | xxxxxxxxxxxxxxxxxxxxxx@gmail.com | 2024-09-26T10:53:39+05:30 | slo  | 2024-09-26T10:53:39+05:30 | []                   | <null>      | <null> | <null>      | {"denominator":"count:datadog.event.tracking.indexation.audit.events{*}.as_count()","metrics":null,"numera>
+------------+----------------------------------+----------------------------------+---------------------------+------+---------------------------+----------------------+-------------+--------+-------------+----------------------------------------------------------------------------------------------------------->

```
</details>
