### PR TITLE
Add support for API URL as env variable

### DIFF
--- a/config/datadog.spc
+++ b/config/datadog.spc
@@ -16,5 +16,9 @@ connection "datadog" {
   # The API URL. By default it is pointed to "https://api.datadoghq.com/"
   # If working with the EU version of Datadog, use "https://api.datadoghq.eu/"
   # Please note that this URL must not end with the /api/ path.
+  # Steampipe will resolve the API URL in below order:
+  #   1. The "api_url" specified here in the config
+  #   2. The `DD_CLIENT_API_URL` environment variable
+  #   3. Assume default value of "https://api.datadoghq.com/"
   # api_url = "https://api.datadoghq.com/"
 }

--- a/datadog/utils.go
+++ b/datadog/utils.go
@@ -22,7 +22,10 @@ func connectV1(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 	// Default to the env var settings
 	apiKey := os.Getenv("DD_CLIENT_API_KEY")
 	appKey := os.Getenv("DD_CLIENT_APP_KEY")
-	apiURL := "https://api.datadoghq.com/"
+	apiURL := os.Getenv("DD_CLIENT_API_URL")
+	if apiURL == "" {
+		apiURL = "https://api.datadoghq.com/"
+	}
 
 	// Prefer config settings
 	config := GetConfig(d.Connection)
@@ -93,7 +96,10 @@ func connectV2(ctx context.Context, d *plugin.QueryData) (context.Context, *data
 	// Default to the env var settings
 	apiKey := os.Getenv("DD_CLIENT_API_KEY")
 	appKey := os.Getenv("DD_CLIENT_APP_KEY")
-	apiURL := "https://api.datadoghq.com/"
+	apiURL := os.Getenv("DD_CLIENT_API_URL")
+	if apiURL == "" {
+		apiURL = "https://api.datadoghq.com/"
+	}
 
 	// Prefer config settings
 	config := GetConfig(d.Connection)

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,10 @@ connection "datadog" {
   # The API URL. By default it is pointed to "https://api.datadoghq.com/"
   # If working with the EU version of Datadog, use "https://api.datadoghq.eu/"
   # Please note that this URL must not end with the /api/ path.
+  # Steampipe will resolve the API URL in below order:
+  #   1. The "api_url" specified here in the config
+  #   2. The `DD_CLIENT_API_URL` environment variable
+  #   3. Assume default value of "https://api.datadoghq.com/"
   # api_url = "https://api.datadoghq.com/"
 }
 ```


### PR DESCRIPTION
Add the possibility of defining the API URL as an environment variable (`DD_CLIENT_API_URL`) as well. 