### PR TITLE
Fix: infinite loop bug in `datadog_security_monitoring_signal` table

### DIFF
--- a/datadog/table_datadog_security_monitoring_signal.go
+++ b/datadog/table_datadog_security_monitoring_signal.go
@@ -107,13 +107,22 @@ func listSecurityMonitoringSignals(ctx context.Context, d *plugin.QueryData, _ *
 			}
 		}
 
+		// Check if there is a next page
 		if meta, ok := resp.GetMetaOk(); ok {
 			if page, pageOk := meta.GetPageOk(); pageOk {
 				if page.HasAfter() {
+					// Set the cursor for the next iteration
 					opts.WithPageCursor(page.GetAfter())
+				} else {
+					// No more pages, break the loop
+					break
 				}
+			} else {
+				// No page info, break the loop
+				break
 			}
 		} else {
+			// No meta info, break the loop
 			break
 		}
 	}

--- a/datadog/table_datadog_security_monitoring_signal.go
+++ b/datadog/table_datadog_security_monitoring_signal.go
@@ -107,22 +107,18 @@ func listSecurityMonitoringSignals(ctx context.Context, d *plugin.QueryData, _ *
 			}
 		}
 
-		// Check if there is a next page
+		// Consolidate pagination logic to a single exit point
+		hasNextPage := false
 		if meta, ok := resp.GetMetaOk(); ok {
 			if page, pageOk := meta.GetPageOk(); pageOk {
 				if page.HasAfter() {
 					// Set the cursor for the next iteration
 					opts.WithPageCursor(page.GetAfter())
-				} else {
-					// No more pages, break the loop
-					break
+					hasNextPage = true
 				}
-			} else {
-				// No page info, break the loop
-				break
 			}
-		} else {
-			// No meta info, break the loop
+		}
+		if !hasNextPage {
 			break
 		}
 	}

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ connection "datadog" {
 
 - `app_key` (required) - [Application keys](https://docs.datadoghq.com/account_management/api-app-keys/#application-keys) in conjunction with organization’s API key, give users access to Datadog’s programmatic API. Application keys are associated with the user account that created them and have the permissions and capabilities of the user who created them. [Get an application key](https://app.datadoghq.com/organization-settings/application-keys). May alternatively be set via the `DD_CLIENT_APP_KEY` environment variable.
 
-- `api_url` (optional) - The API URL used for all requests. Defaults to "https://api.datadoghq.com/". If working with the EU version, this should be changed to "https://api.datadoghq.eu/".
+- `api_url` (optional) - The API URL used for all requests. Defaults to "https://api.datadoghq.com/". If working with the EU version, this should be changed to "https://api.datadoghq.eu/".  May alternatively be set via the `DD_CLIENT_API_URL` environment variable.
 
 ## Get Involved
 


### PR DESCRIPTION
This PR fixes a bug in the `datadog_security_monitoring_signal` table that caused an infinite loop when querying for signals. When a query was executed, the table would get stuck fetching the last page of results repeatedly.

The pagination logic in the `listSecurityMonitoringSignals` function did not correctly terminate the for loop. When the final page of results was retrieved, the condition `page.HasAfter()` would return `false`. However, there was no corresponding break statement to exit the loop. As a result, the function would continuously re-request the last page with the same cursor.

The fix introduces an `else` block to the pagination check. Now, when `page.HasAfter()` is `false`, the code explicitly calls `break` to exit the loop, ensuring that pagination terminates correctly once all results have been streamed.

# Example query results
<details>
  <summary>Results</summary>

```sql

 select
  count(id),
  title
from
  datadog_security_monitoring_signal
where
  timestamp >= (current_date - interval '93' day) and 
  filter_query = 'status:(critical OR high OR medium)' 
  group by title

```

```
+-------+------------------------------------------------------------------------------+
| count | title                                                                        |
+-------+------------------------------------------------------------------------------+
| 9     | AWS ConsoleLogin without MFA triggered Impossible Travel scenario            |
| 1     | AWS IAM AdministratorAccess policy was applied to a role                     |
| 20    | Google Cloud Root or Break Glass account usage detected                      |
| 1     | Administrative privileges assigned to a user, group or role                  |
| 5     | Anomalous amount of Autoscaling Group events                                 |
| 3     | Anomalous amount of access denied events for AWS EC2 Instance                |
| 2     | Attempt to exfiltrate a LastPass item by user                                |
| 1     | Brute force attack on an Auth0 user - Successful                             |
| 1     | Exchange Online mail forwarding rule enabled                                 |
| 21    | Impossible Travel Zoom login                                                 |
| 7     | Impossible travel event observed from LastPass user                          |
| 4     | New AWS account seen assuming a role into AWS account                        |
| 1     | Cognito user reported suspicious activity                                    |
| 1     | Potential administrative port open to the world via AWS security group - SSH |
| 25    | Security group open to the world - SG open to world                          |
| 1     | Unusual LastPass device authorization activity                               |
+-------+------------------------------------------------------------------------------+
```
</details> 